### PR TITLE
tidy up inline documentation and clarify $ variable

### DIFF
--- a/lib/sinatra/main.rb
+++ b/lib/sinatra/main.rb
@@ -3,8 +3,8 @@ require 'sinatra/base'
 module Sinatra
   class Application < Base
 
-    # we assume that the first file that requires 'sinatra' is the
-    # app_file. all other path related options are calculated based
+    # We assume that the first file that requires 'sinatra' is the
+    # app_file. All other path related options are calculated based
     # on this path by default.
     set :app_file, caller_files.first || $0
 
@@ -22,9 +22,9 @@ module Sinatra
     end
   end
 
-  at_exit { Application.run! if $!.nil? && Application.run? }
+  at_exit { Application.run! if $ERROR_INFO.nil? && Application.run? }
 end
 
-# include would include the module in Object
-# extend only extends the `main` object
+# include would include the module in Object whereas
+# extend only extends the `main` object.
 extend Sinatra::Delegator


### PR DESCRIPTION
Capitalized the inline documentation and expanded $! into its more readable synonym. Not sure if this is useful but I'm always forgetting what those Perl-like dollar variables mean. I don't think $0 has a synonym.
